### PR TITLE
Allow any event data to be passed to Fliplet's analytics log

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -1,6 +1,6 @@
 (function () {
   if (Fliplet.Env.get('interact')) {
-    return; // do not track in edit mode  
+    return; // do not track in edit mode
   }
 
   $('[data-analytics-id]').each(function () {
@@ -18,14 +18,10 @@
       // Screen data capture
       Fliplet.App.Analytics.pageView(pageTitle);
     });
-    
+
     // Intercepts events
     Fliplet.Analytics.subscribe('trackEvent', function (event) {
-      Fliplet.App.Analytics.event({
-        category: event.category,
-        action: event.action,
-        label: event.label
-      });
+      Fliplet.App.Analytics.event(event);
     });
   });
 })();


### PR DESCRIPTION
In the case of https://github.com/Fliplet/fliplet-studio/issues/3806 the `event` object was passed with

```js
{ category, action, title }
```

...instead of...

```js
{ category, action, label }
```

However, because the Analytics widget is only picking the `{ category, action, label }` keys, the `title` attribute was not sent to Fliplet Analytics to be stored. Granted the advanced directory should be using `label` instead of `title` to match GA standards, having the ability to store additional data that GA doesn't use would enhance the capability of Fliplet Analytics.